### PR TITLE
Add fish 39 and 40 to anglerquestfish.py

### DIFF
--- a/lihzahrd/header/anglerquestfish.py
+++ b/lihzahrd/header/anglerquestfish.py
@@ -43,7 +43,11 @@ class AnglerQuestFish(enum.IntEnum):
     TROPICAL_BARRACUDA = 38
 
     # none of the other tools know what fish this is ... *shrug*
+    # we now know it's a SCARAB_FISH; UNKNOWN1 remains for back-compatibility.
     UNKNOWN1 = 39
+    SCARAB_FISH = 39
+
+    SCORPIO_FISH = 40
 
     def __repr__(self):
         return f"{self.__class__.__name__}.{self.name}"

--- a/lihzahrd/header/anglerquestfish.py
+++ b/lihzahrd/header/anglerquestfish.py
@@ -41,13 +41,11 @@ class AnglerQuestFish(enum.IntEnum):
     MUDFISH = 36
     SLIMEFISH = 37
     TROPICAL_BARRACUDA = 38
-
-    # none of the other tools know what fish this is ... *shrug*
-    # we now know it's a SCARAB_FISH; UNKNOWN1 remains for back-compatibility.
-    UNKNOWN1 = 39
     SCARAB_FISH = 39
-
     SCORPIO_FISH = 40
+
+    # Backward compatibility
+    UNKNOWN1 = 39  # SCARAB_FISH
 
     def __repr__(self):
         return f"{self.__class__.__name__}.{self.name}"


### PR DESCRIPTION
The AnglerFishQuest tag can take a new value (40).

Currently, lihazahrd.World() crashes when trying to load a world with this value.

I verified ingame that a value of 40 corresponds to the Scorpio Fish. This commit adds a value to the AnglerQuestFish enum for this new option. It also adds a label for fish 39 (the Scarab Fish), which was previously unknown.

For backwards compatibility, I left the old name (UNKNOWN1) as-is.